### PR TITLE
work around a problem with Microsoft.SourceLink.Common.GenerateSourceLinkFile task deleting the generated sourcelink file

### DIFF
--- a/src/GitLabSourceLink/build/Genbox.GitLabSourceLink.targets
+++ b/src/GitLabSourceLink/build/Genbox.GitLabSourceLink.targets
@@ -21,7 +21,7 @@
     </Microsoft.Build.Tasks.Git.GetUntrackedFiles>
 
     <GenerateSourceLinkFile UntrackedFiles="@(EmbeddedFiles)"
-                            OutputFile="$(IntermediateOutputPath)$(AssemblyName).sourcelink.json"
+                            OutputFile="$(IntermediateOutputPath)$(AssemblyName).genbox.sourcelink.json"
                             SourceFiles="@(Compile)"
                             SourceRoots="@(SourceRoot)"
                             GitLabUrl="$(ScmRepositoryUrl)"
@@ -32,7 +32,7 @@
 
     <PropertyGroup>
       <PathMap>$(Root)=/_/,$(PathMap)</PathMap>
-      <SourceLink>$(IntermediateOutputPath)$(AssemblyName).sourcelink.json</SourceLink>
+      <SourceLink>$(IntermediateOutputPath)$(AssemblyName).genbox.sourcelink.json</SourceLink>
     </PropertyGroup>
 
   </Target>


### PR DESCRIPTION
Since SourceLink is enabled by default in .NET8, the default `GenerateSourceLinkFile` task always runs, and if it doesn't generate any output, but the sourcelink file exists on disk, it deletes it: https://github.com/dotnet/sourcelink/blob/8.0.0/src/SourceLink.Common/GenerateSourceLinkFile.cs#L123.

This causes a build failures like this:

    CSC : error CS0016: Could not write to output file '\path\to\YourProject.sourcelink.json' -- 'Could not find file '\path\to\YourProject.sourcelink.json'.'

Work around it by using a more specific sourcelink file name that is unlikely to clash with the default one and won't be deleted.